### PR TITLE
fix(refresh): do not delete keyring password if network unavailable

### DIFF
--- a/pkg/cmd/refresh.go
+++ b/pkg/cmd/refresh.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -70,6 +72,15 @@ func executeRefresh(cmd *Cmd) error {
 		saml, newSessionCookie, err = okta.Login(cmd.Config, cmd.Input, "", password)
 	}
 	if err != nil {
+		// Check if error is due to a network problem. If it is a network error,
+		// return error but do not delete the password from the keyring.
+		if urlError, ok := err.(*url.Error); ok {
+			if _, ok := urlError.Err.(*net.OpError); ok {
+				fmt.Println("Unable to connect with Okta. Make sure you are connected to the internet and try again.")
+				return err
+			}
+		}
+
 		deleteErr := keyring.Delete(keyringPasswordService, cmd.Config.Username)
 		switch deleteErr {
 		case nil:


### PR DESCRIPTION
If we run aws-creds without being connected to the internet the Okta API
call will return a network error. In the event of an error we naively
assume that our credentials are wrong and delete them from the system
keyring. There is a possibility that the error was caused due to
conenctivity issues and the credentials are actually OK. This change
detects if the current error is a net.OpError and if so returns an
explanatory messages and skips deleting the information from the system
keyring.