### PR TITLE
Minor(UX): Ask for one-time passowrd, not totp

### DIFF
--- a/pkg/okta/factors.go
+++ b/pkg/okta/factors.go
@@ -52,7 +52,7 @@ func promptForFactor(factors []*Factor, p input.Prompter) (int, error) {
 func verifyTOTP(c *Client, f *Factor, a *Auth, p input.Prompter) error {
 	var resp io.Reader
 	for {
-		totp, err := p.Prompt("Enter TOTP: ")
+		totp, err := p.Prompt("Enter Okta One-Time Password (TOTP): ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A user hit an issue where the term TOTP during initial setup was not intuitive, resulting in entering the wrong information.

This should resolve the issue by being explicit about what data we're asking for.

Will result in a patch version bump.