### PR TITLE
Makes using keyring optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ tags
 
 # End of https://www.gitignore.io/api/go,vim,macos
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ $ aws s3 ls                          # Equivalent
 
 > Note: these credentials expire every hour, so you will need to re-run `aws-creds -p $PROFILE_NAME` periodically.
 
+### Headless Linux / WSL Users
+
+This utility uses a keyring library that is incompatible with certain linux configurations. To disable keyring caching, modify the `~/.aws-creds/config` file to include `"enable_keyring" : false,` after setting up the tool. 
+
 ## Building
 
 `aws-creds` has a Makefile with helper commands:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	OktaHost            string     `json:"okta_host,omitempty"`
 	OktaAppPath         string     `json:"okta_app_path,omitempty"`
 	PreferredFactorType string     `json:"preferred_factor_type,omitempty"`
+	EnableKeyring       bool       `json:"enable_keyring"`
 	Profiles            []*Profile `json:"profiles"`
 	CredentialsFilepath string     `json:"-"`
 	filepath            string
@@ -48,7 +49,7 @@ func New(fp string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Config{CredentialsFilepath: cfp, filepath: fp}, nil
+	return &Config{CredentialsFilepath: cfp, filepath: fp, EnableKeyring: true}, nil
 }
 
 // Load loads data from the config file into the Config struct.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -52,6 +52,7 @@ func TestConfig(t *testing.T) {
 	conf1.Username = "test_user"
 	conf1.OktaHost = "https://test.okta.com"
 	conf1.OktaAppPath = "/home/amazon_aws/0oa54k1gk2ukOJ9nGDt7/252"
+	conf1.EnableKeyring = true
 	conf1.Profiles = []*Profile{
 		{"staging", "arn:staging", 3600},
 		{"production", "arn:production", 3600},


### PR DESCRIPTION
Hi all,

I quickly wrote in an optional config to make keyring caching optional for WSL / headless linux users. This is my first time writing Go code, so there might be things that I did poorly or unidiomatically. Also, this works with keyring disabled, but I have no way of testing that this didn't break certain keyring functionality. 

This addresses #39 

Slack context: https://lob.slack.com/archives/C02A84AKPL3/p1639175379232100