### PR TITLE
add empty string check and test for profile.RoleARN

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -20,6 +20,10 @@ var (
 
 // GetCreds fetches AWS credentials using a SAML response.
 func GetCreds(svc stsiface.STSAPI, saml *okta.SAMLResponse, profile *config.Profile) (*sts.Credentials, error) {
+	if profile.RoleARN == "" {
+		return nil, fmt.Errorf("The profile role_arn must be provided.")
+	}
+
 	roles, duration := parseSAMLAttributes(saml)
 
 	// Override default duration

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -55,3 +55,28 @@ func TestGetCreds(t *testing.T) {
 		t.Errorf("expected error when getting creds for an invalid profile")
 	}
 }
+
+func TestGetCredsNilRoleARN(t *testing.T) {
+	roleARN := ""
+	duration := "1800"
+	creds := test.NewCredentials()
+	svc := &test.MockSTS{Creds: creds}
+	saml := &okta.SAMLResponse{
+		Attributes: []okta.Attribute{
+			{
+				Name:   roleSAMLAttribute,
+				Values: []string{fmt.Sprintf("principal_arn,%s", roleARN)},
+			},
+			{
+				Name:   durationSAMLAttribute,
+				Values: []string{duration},
+			},
+		},
+	}
+	profile := &config.Profile{Name: "staging", RoleARN: roleARN}
+
+	_, err := GetCreds(svc, saml, profile)
+	if err == nil {
+		t.Fatalf("expected error when profile ARN is empty string")
+	}
+}


### PR DESCRIPTION
Add a check that the role_arn loaded from the config file isn't an empty string.
It errors out in this case.

### Background

- There was a typo added to my `~/.aws-creds/config` file: the key was `role_arm` intead of `role_arn`.
- Parsing the config file didn't find the role_arn key, so the value defaulted to an empty string.
- The `staging` account is the first item in the list of all available profiles retrieved from okta.
- When role_arn is an empty string, it automatically picks the first profile in the list.
